### PR TITLE
ci: add a docker based build for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: xenial
+language: c
+services:
+  - docker
+script:
+  - ./ci/run-docker-ci.sh
+
+# vim: set sw=2 sts=2 :

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,50 @@
+FROM centos:7
+
+# Install PostgreSQl Repo RPM
+RUN curl -O https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+
+RUN yum install -y epel-release ./pgdg*.rpm
+
+RUN yum install -y \
+        sudo \
+        which \
+        rpm-build \
+        libtool \
+        postgresql94 \
+        postgresql94-devel \
+        glib2-devel \
+        python-devel \
+        jansson-devel \
+        libini_config-devel \
+        openssl-devel \
+        libattr-devel \
+        sg3_utils-devel \
+        postgresql94-server \
+        postgresql94-contrib \
+        glib2 \
+        jansson \
+        libini_config \
+        openssl \
+        libattr \
+        python \
+        python-argparse \
+        python-yaml \
+        clustershell \
+        python-psycopg2 \
+        attr \
+        mtx
+
+# TODO: lin_tape ltfssde and QuadstorVTL setup
+
+RUN sudo -u postgres /usr/pgsql-9.4/bin/initdb -D /tmp/pg_data  \
+                     --auth-local trust
+
+ENV PKG_CONFIG_PATH /usr/pgsql-9.4/lib/pkgconfig/
+
+WORKDIR /phobos
+
+COPY . .
+
+# FIXME: postgresql is started in this container because most tests have
+# hardcoded localhost postgresql connection information
+CMD ["/bin/sh", "-c", "START_PGSQL=true ./ci/run-ci.sh"]

--- a/ci/run-ci.sh
+++ b/ci/run-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 # vim:expandtab:shiftwidth=4:tabstop=4:
@@ -9,6 +9,19 @@
 # Licensed under the terms of the GNU Lesser GPL License version 2.1
 
 set -xe
+
+function pgsql_start() {
+    if [ -n "$START_PGSQL" ]; then
+        sudo -u postgres /usr/pgsql-9.4/bin/pg_ctl \
+            -D /tmp/pg_data -l /tmp/postgres.log start
+    fi
+}
+
+function pgsql_stop() {
+    if [ -n "$START_PGSQL" ]; then
+        sudo -u postgres /usr/pgsql-9.4/bin/pg_ctl -D /tmp/pg_data -m fast stop
+    fi
+}
 
 #set phobos root as cwd from phobos/ci directory
 cur_dir=$(dirname $(readlink -m $0))
@@ -24,7 +37,12 @@ make
 # FIXME: when cloning the repo, some scripts do not have o+rx
 # permissions, it is however necessary to execute them as postgres
 chmod o+rx . .. ./scripts/phobos_db{,_local}
+
+# Manually start postgresql (handy for container CI)
+pgsql_start
+trap pgsql_stop EXIT
+
 sudo -u postgres ./scripts/phobos_db_local drop_db || true
 sudo -u postgres ./scripts/phobos_db_local setup_db -s -p phobos
-export VERBOSE=1
+export VERBOSE=1 DEBUG=1
 sudo -E make check

--- a/ci/run-docker-ci.sh
+++ b/ci/run-docker-ci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+cur_dir="$(dirname $(readlink -m ${BASH_SOURCE[0]}))"
+cd "$cur_dir/.."
+
+docker build -f "$cur_dir/Dockerfile" . -t phobos
+# Need privileges for process tracing (and in the future for tape access)
+docker run --privileged -v /run/systemd/journal/dev-log:/dev/log phobos


### PR DESCRIPTION
Current docker image works for tests without QuadstorVTL.
Given that QuadstorVTL compiles and inserts kernel modules on
installation, using it with the Docker based CI will require further
work on the host VM.